### PR TITLE
Add slowmo option to ferrum driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ ENV["CAPYBARA_ARTIFACTS"] # used for Capybara.save_path
 ENV["CHROME_URL"] # used for setting a remote chrome instance for Cuprite
 ENV["PROCESS_TIMEOUT"] # How long to wait before killing the process, default is 5 seconds
 ENV["CI"] # Whether or not to run Cuprite in headless mode, defaults to true.
+ENV["SLOWMO"] # Delay in seconds before sending a command (default 0). Also see https://github.com/rubycdp/ferrum#customization
 ```
 
 ## I don't want to use Cuprite.

--- a/lib/evil_systems/register_cuprite.rb
+++ b/lib/evil_systems/register_cuprite.rb
@@ -28,7 +28,7 @@ module EvilSystems
             browser_options: RemoteChrome.connected? ? {"no-sandbox" => nil} : {},
             headless: ENV.fetch("CI", "true") == "true",
             process_timeout: process_timeout,
-            slowmo: ENV.fetch("SLOWMO", 0),
+            slowmo: ENV.fetch("SLOWMO", 0).to_f,
             inspector: true
           }.merge(remote_options)
         )

--- a/lib/evil_systems/register_cuprite.rb
+++ b/lib/evil_systems/register_cuprite.rb
@@ -28,6 +28,7 @@ module EvilSystems
             browser_options: RemoteChrome.connected? ? {"no-sandbox" => nil} : {},
             headless: ENV.fetch("CI", "true") == "true",
             process_timeout: process_timeout,
+            slowmo: ENV.fetch("SLOWMO", 0),
             inspector: true
           }.merge(remote_options)
         )


### PR DESCRIPTION
This could be especially usable when dealing with actioncable responses that require `sleep` ing a lot