### PR TITLE
Rename driver to `:evil_cuprite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ require 'evil_systems'
 EvilSystems.initial_setup
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :cuprite
+  driven_by :evil_cuprite
 
   include EvilSystems::Helpers
 end
@@ -102,11 +102,11 @@ EvilSystems.initial_setup(task: "webpacker:compile", silent: false)
 
 ### Settings
 
-- [x] - Automatically registers a `:cuprite` driver if `Capybara::Cuprite`
+- [x] - Automatically registers a `:evil_cuprite` driver if `Capybara::Cuprite`
 is defined.
 
 - [x] - Automatically sets Capybara's default and javascript driver to
-`:cuprite`
+`:evil_cuprite`
 
 - [x] - Automatically sets `Capybara.app_host`
 

--- a/lib/evil_systems/register_cuprite.rb
+++ b/lib/evil_systems/register_cuprite.rb
@@ -6,7 +6,7 @@ module EvilSystems
   # See https://github.com/rubycdp/cuprite
   module RegisterCuprite
     # Registers the Cuprite driver. Can be used via:
-    # driven_by :cuprite, using: :chrome, screen_size: [1400, 1400]
+    # driven_by :evil_cuprite, using: :chrome, screen_size: [1400, 1400]
     # The initial setup prior to the class ApplicationSystemTestCase, runs before the entire test suite.
     # @return [void]
     def self.initial_setup
@@ -20,7 +20,7 @@ module EvilSystems
 
       remote_options = RemoteChrome.options
 
-      ::Capybara.register_driver(:cuprite) do |app|
+      ::Capybara.register_driver(:evil_cuprite) do |app|
         ::Capybara::Cuprite::Driver.new(
           app,
           **{
@@ -37,4 +37,4 @@ module EvilSystems
   end
 end
 
-Capybara.default_driver = Capybara.javascript_driver = :cuprite
+Capybara.default_driver = Capybara.javascript_driver = :evil_cuprite

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,7 +7,7 @@ require "evil_systems"
 EvilSystems.initial_setup
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :cuprite
+  driven_by :evil_cuprite
 
   include EvilSystems::Helpers
 end


### PR DESCRIPTION
In rails 7 there is already a driver for `:cuprite` and it doesn't work to overwrite it. I recently fixed the same thing for selenium.