### PR TITLE
Add a note about installing the gem into the test group

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ gem 'cuprite' # Optional
 gem 'selenium-webdriver' # Not required if using Cuprite and using Rails >= 6.1
 ```
 
+> Note: `bundle add` by default appends the gem to the bottom of your `Gemfile`, which means not in the `test` group of gems. If the `capybara` gem is in the `test` group, but `evil_systems` is not, you will not be able to load your application in production. Be sure that `evil_systems` is placed in the same group as `capybara` (we recommend the `test` group).
+
 ## Setup
 
 ### Minitest


### PR DESCRIPTION
I experienced problems in production after using `bundle add evil_systems` to install the gem. Specifically, I experienced this error on application load:
```
lib/evil_systems/register_cuprite.rb:40:in `<main>': uninitialized constant Capybara (NameError)
    Capybara.default_driver = Capybara.javascript_driver = :evil_cuprite
```

This was because the `evil_systems` gem was declared at the root of my `Gemfile` (at the bottom), while `capybara` was declared in the `test` group. I needed to manually move the gem declaration in the `test` group.